### PR TITLE
Fix esphome component compilation with ESP-IDF toolchain

### DIFF
--- a/esphome/components/bosch_ebike_ldi/bosch_ebike_ldi.cpp
+++ b/esphome/components/bosch_ebike_ldi/bosch_ebike_ldi.cpp
@@ -83,11 +83,7 @@ static void log_hex(const char *prefix, const uint8_t *buf, size_t len) {
     snprintf(&hex[i * 3], 4, "%02x ", buf[i]);
   }
   hex[to_print > 0 ? (to_print * 3 - 1) : 0] = '\0';
-  if (len > 64) {
-    ESP_LOGD(TAG, "%s len=%u: %s …", prefix, (unsigned) len, hex);
-  } else {
-    ESP_LOGD(TAG, "%s len=%u: %s", prefix, (unsigned) len, hex);
-  }
+  ESP_LOGD(TAG, "%s len=%u: %s%s", prefix, (unsigned) len, hex, len > 64 ? " …" : "");
 }
 
 // Build raw advertising payload including Service Solicitation 128-bit (AD 0x15).

--- a/esphome/components/bosch_ebike_ldi/bosch_ebike_ldi.cpp
+++ b/esphome/components/bosch_ebike_ldi/bosch_ebike_ldi.cpp
@@ -82,7 +82,7 @@ static void log_hex(const char *prefix, const uint8_t *buf, size_t len) {
   for (size_t i = 0; i < to_print; i++) {
     snprintf(&hex[i * 3], 4, "%02x ", buf[i]);
   }
-  hex[to_print * 3 ? (to_print * 3 - 1) : 0] = '\0';
+  hex[to_print > 0 ? (to_print * 3 - 1) : 0] = '\0';
   if (len > 64) {
     ESP_LOGD(TAG, "%s len=%u: %s …", prefix, (unsigned) len, hex);
   } else {


### PR DESCRIPTION
Since esphome 2026.5.0 there is native ESP-IDF toolchain support. However int in bool context is not allowed. 

```
bridge/src/esphome/components/bosch_ebike_ldi/bosch_ebike_ldi.cpp:85:16: error: '*' in boolean context, suggest '&&' instead [-Werror=int-in-bool-context]
   85 |   hex[to_print * 3 ? (to_print * 3 - 1) : 0] = '\0';
```

This PR fixes this issue. My bike still connects and shows data. 