### PR TITLE
fix(#37): Add more codes for modes of G series

### DIFF
--- a/custom_components/ha_bosch_ebike/profile_extra.py
+++ b/custom_components/ha_bosch_ebike/profile_extra.py
@@ -40,6 +40,11 @@ ASSIST_MODE_NAMES: dict[str, str] = {
     "A100G0AUTO": "AUTO",
     "A100GAAAA0": "TURBO",
     "A100GAAAD0": "ECO",
+    "A100ECOP38": "ECO+",
+    "A100GAAAC0": "TOUR",
+    "A100GAAAF0": "TOUR+",
+    "A100GAAAB0": "eMTB",
+    "A100GAAAE0": "SPORT",
 }
 
 


### PR DESCRIPTION
I installed some further modes on my bike to retrieve the internal codes. I hope this helps. 